### PR TITLE
Update npc_edit_form.jade

### DIFF
--- a/views/npc_edit_form.jade
+++ b/views/npc_edit_form.jade
@@ -143,7 +143,7 @@ block content
 
             $('button.delete_npc').click(function () {
                 var NPC_id = $(this).attr('npc_id');
-                var deleteURL = "/data/delete/:" + NPC_id;
+                var deleteURL = "/data/delete/" + NPC_id;
                 console.log('**************'+NPC_id)
                 console.log('**************'+deleteURL)
                 $.ajax(


### PR DESCRIPTION
This should fix for your delete problem. The URL has a : in which is being considered part of the ID. 

Also, change line 17 in npcs.jade and remove the : there too. 

The delete is working although the JQuery selector is not removing it from the view. JQuery is assuming the ID is the npc.id, but in NPC.jade you are setting the id to the NPC's name.  Pick one attribute and use in both places. 
